### PR TITLE
Adding default value

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-export const normalize = (input, key) => input.reduce((result, item) => {
+export const normalize = (input, key = "id") => input.reduce((result, item) => {
   result[item[key]] = item;
 
   return result;


### PR DESCRIPTION
I think the value "id" could be a proper default value of the `key` parameter so this way the `normalize` method can be used without passing any value to the `key` parameter.

So this way `normalize(users, "id")` equals to `normalize(users)`.